### PR TITLE
Short year and slash separator in date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "rusk"
-version = "0.6.0-beta"
+version = "0.6.1-beta"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -69,12 +69,10 @@ rusk add Buy groceries
 
 # Add a task with a deadline
 rusk add Finish project report --date 31-12-2025
-
-# When using --date or -d flag, shell completions (see [Shell Completion](#shell-completion)) suggest default dates:
-# - Today (current date)
-# - Tomorrow (current date + 1 day)
-# - One week ahead (current date + 7 days)
-# - Two weeks ahead (current date + 14 days)
+# Or with short year and slash separator:
+rusk add Finish project report --date 31/12/25
+# Leading zero for day is optional:
+rusk add Finish project report --date 1-12-25
 
 # View all tasks
 rusk list
@@ -94,7 +92,7 @@ rusk edit 1 Complete the project documentation
 rusk edit 1 --date 25-12-2025
 
 # Edit both text and date
-rusk edit 1 Update documentation --date 25-12-2025
+rusk edit 1 Update documentation --date 23/12/25
 
 # Delete a task
 rusk del 1
@@ -130,7 +128,7 @@ rusk edit 1
 rusk edit 1 -d
 
 # Interactive editing of tasks in sequence
-rusk edit 1 2 3
+rusk edit 1 4 5
 ```
 
 
@@ -295,9 +293,6 @@ mkdir -p ~/.config/powershell
 rusk completions show powershell > ~/.config/powershell/rusk-completions.ps1
 Add-Content $PROFILE ". ~/.config/powershell/rusk-completions.ps1"
 ```
-
-
-
 ### Database Location
 
 By default, rusk stores tasks to:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,10 @@ impl TaskManager {
             anyhow::bail!("Task text cannot be empty");
         }
 
-        let date = date.and_then(|d| NaiveDate::parse_from_str(&d, "%d-%m-%Y").ok());
+        let date = date.and_then(|d| {
+            let normalized = normalize_date_string(&d);
+            NaiveDate::parse_from_str(&normalized, "%d-%m-%Y").ok()
+        });
         let id = self.generate_next_id()?;
 
         let task = Task {
@@ -226,7 +229,8 @@ impl TaskManager {
                 }
 
                 if let Some(ref new_date) = date {
-                    let parsed_date = NaiveDate::parse_from_str(new_date, "%d-%m-%Y").ok();
+                    let normalized = normalize_date_string(new_date);
+                    let parsed_date = NaiveDate::parse_from_str(&normalized, "%d-%m-%Y").ok();
                     if task.date != parsed_date {
                         task.date = parsed_date;
                         was_changed = true;
@@ -499,6 +503,34 @@ impl TaskManager {
 
         Ok(())
     }
+}
+
+/// Normalize date string: replace '/' with '-', and convert short year (25) to full year (2025)
+/// Supports formats: DD-MM-YYYY, DD/MM/YYYY, DD-MM-YY, DD/MM/YY
+pub fn normalize_date_string(date_str: &str) -> String {
+    let mut normalized = date_str.replace('/', "-");
+    
+    // Check if year is short (1-2 digits without leading zeros) and convert to full year
+    // Pattern: DD-MM-YY or DD/MM/YY -> DD-MM-2025
+    // But NOT: DD-MM-0001 (4 digits, even if parsed as 1)
+    let parts: Vec<&str> = normalized.split('-').collect();
+    if parts.len() == 3 {
+        if let Some(year_str) = parts.get(2) {
+            let year_str = year_str.trim();
+            // Only convert if year string is 1-2 digits (no leading zeros)
+            if year_str.len() <= 2 && !year_str.is_empty() {
+                if let Ok(year) = year_str.parse::<u16>() {
+                    // If year is 1-2 digits (0-99), assume 2000s
+                    if year < 100 {
+                        let full_year = 2000 + year;
+                        normalized = format!("{}-{}-{}", parts[0], parts[1], full_year);
+                    }
+                }
+            }
+        }
+    }
+    
+    normalized
 }
 
 /// Parse flexible ID input (space-separated, comma-separated, or mixed)

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use rusk::TaskManager;
+use rusk::{TaskManager, normalize_date_string};
 
 #[test]
 fn test_cli_add_command() {
@@ -284,6 +284,10 @@ fn test_cli_date_handling() {
         "31-12-2025",
         "29-02-2024", // Leap year
         "15-06-2025",
+        "01/01/2025", // Slash separator
+        "31/12/2025", // Slash separator
+        "12-12-25",   // Short year (25 -> 2025)
+        "12/12/25",   // Short year with slash
     ];
 
     for (i, date) in valid_dates.iter().enumerate() {
@@ -291,7 +295,9 @@ fn test_cli_date_handling() {
         assert!(result.is_ok());
 
         let task = &tm.tasks[i];
-        let parsed_date = NaiveDate::parse_from_str(date, "%d-%m-%Y").unwrap();
+        // Normalize date (replace / with -, convert short year) before parsing
+        let normalized = normalize_date_string(date);
+        let parsed_date = NaiveDate::parse_from_str(&normalized, "%d-%m-%Y").unwrap();
         assert_eq!(task.date, Some(parsed_date));
     }
 
@@ -301,7 +307,6 @@ fn test_cli_date_handling() {
         "32-01-2025", // Invalid day
         "30-02-2025", // Invalid day for February
         "invalid-date",
-        "01/01/2025", // Wrong format
         "2025-01-01", // Wrong format (old YYYY-MM-DD)
     ];
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,6 +2,7 @@ use chrono::NaiveDate;
 use rusk::Task;
 
 // Helper function to create test tasks
+#[allow(dead_code)]
 pub fn create_test_task(id: u8, text: &str, done: bool) -> Task {
     Task {
         id,

--- a/tests/completions_install_tests.rs
+++ b/tests/completions_install_tests.rs
@@ -220,7 +220,7 @@ fn test_completion_show_output() {
 
 #[test]
 fn test_completion_paths_use_correct_filenames() {
-    let temp_dir = TempDir::new().unwrap();
+    let _temp_dir = TempDir::new().unwrap();
     
     let test_cases = vec![
         (Shell::Bash, "rusk"),

--- a/tests/edge_case_tests.rs
+++ b/tests/edge_case_tests.rs
@@ -258,7 +258,6 @@ fn test_edge_case_invalid_date_formats() {
         "00-01-2025", // Invalid day (0)
         "32-13-2025", // Both invalid
         "invalid-date",
-        "01/01/2025",       // Wrong format
         "2025-01-01",       // Wrong format (old YYYY-MM-DD)
         "01.01.2025",       // Wrong format
         "01_01_2025",       // Wrong format


### PR DESCRIPTION
Added short year format (d-m-yy), added slash separator in date (d/m/yy), tests and updated readme.